### PR TITLE
Allow to keep existing content of files

### DIFF
--- a/file.go
+++ b/file.go
@@ -117,10 +117,22 @@ func (f *File) Get(ctx Context) (current ResourceState, err error) {
 }
 
 func (f *File) Create(ctx Context) error {
-	return f.createWithContent(ctx, f.Content)
+	err := f.createFile(ctx)
+	if err != nil {
+		return err
+	}
+	err = f.writeContent(ctx)
+	if err != nil {
+		return err
+	}
+	err = f.ensureMode(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func (f *File) createWithContent(ctx Context, content FileContent) error {
+func (f *File) createFile(ctx Context) error {
 	provider := f.provider(ctx)
 	path := filepath.Join(provider.Prefix, f.Path)
 
@@ -135,18 +147,29 @@ func (f *File) createWithContent(ctx Context, content FileContent) error {
 		return os.Mkdir(path, f.mode())
 	}
 
-	if content != nil {
-		err := safeWriteContent(ctx, path, content, f.MD5)
-		if err != nil {
-			return err
-		}
-	} else if f.Content == nil {
-		created, err := os.Create(path)
-		if err != nil {
-			return err
-		}
-		defer created.Close()
+	created, err := os.OpenFile(path, os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
 	}
+	created.Close()
+
+	return nil
+}
+
+func (f *File) writeContent(ctx Context) error {
+	if f.Content == nil {
+		return nil
+	}
+
+	provider := f.provider(ctx)
+	path := filepath.Join(provider.Prefix, f.Path)
+
+	return safeWriteContent(ctx, path, f.Content, f.MD5)
+}
+
+func (f *File) ensureMode(ctx Context) error {
+	provider := f.provider(ctx)
+	path := filepath.Join(provider.Prefix, f.Path)
 
 	if err := os.Chmod(path, f.mode()); err != nil {
 		return fmt.Errorf("failed to set mode: %w", err)
@@ -176,7 +199,10 @@ func safeWriteContent(ctx Context, path string, content FileContent, md5Sum stri
 		return errors.New("md5 checksum of content differs")
 	}
 
-	os.Remove(path)
+	err = os.Remove(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("cannot replace file %s", path)
+	}
 	return os.Rename(tmpFile.Name(), path)
 }
 
@@ -186,6 +212,7 @@ func (f *File) Update(ctx Context) error {
 	if f.Absent {
 		return os.Remove(path)
 	}
+
 	if f.Force {
 		info, err := os.Stat(path)
 		if err == nil && info != nil && f.Directory != info.IsDir() {
@@ -194,12 +221,23 @@ func (f *File) Update(ctx Context) error {
 				return err
 			}
 		}
+
+		return f.Create(ctx)
 	}
-	content := f.Content
-	if f.KeepExistingContent {
-		content = nil
+
+	if !f.KeepExistingContent {
+		err := f.writeContent(ctx)
+		if err != nil {
+			return err
+		}
 	}
-	return f.createWithContent(ctx, content)
+
+	err := f.ensureMode(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type FileState struct {

--- a/file_test.go
+++ b/file_test.go
@@ -440,10 +440,12 @@ func TestDirectoryToFileUpdate(t *testing.T) {
 	manager := NewManager()
 	manager.RegisterProvider(providerName, &provider)
 
+	content := "somecontent"
 	resource := File{
 		Provider: providerName,
 		Path:     "some-file",
 		Force:    true,
+		Content:  FileContentLiteral(content),
 	}
 	resources := Resources{&resource}
 
@@ -464,6 +466,10 @@ func TestDirectoryToFileUpdate(t *testing.T) {
 	info, err := os.Stat(filepath.Join(provider.Prefix, resource.Path))
 	assert.NoError(t, err)
 	assert.False(t, info.IsDir())
+
+	found, err := os.ReadFile(filepath.Join(provider.Prefix, resource.Path))
+	assert.NoError(t, err)
+	assert.Equal(t, content, string(found))
 }
 
 func TestFileModeUpdate(t *testing.T) {

--- a/file_test.go
+++ b/file_test.go
@@ -132,6 +132,122 @@ func TestFileContentUpdate(t *testing.T) {
 	require.Empty(t, result)
 }
 
+func TestFilePresentWithKeepExisting(t *testing.T) {
+	providerName := "test-files"
+	provider := FileProvider{
+		Prefix: t.TempDir(),
+	}
+	manager := NewManager()
+	manager.RegisterProvider(providerName, &provider)
+
+	resource := File{
+		Provider:            providerName,
+		Path:                "/sample-file.txt",
+		KeepExistingContent: true,
+	}
+	resources := Resources{&resource}
+
+	state, err := resource.Get(manager.Context(nil))
+	require.NoError(t, err)
+	assert.False(t, state.Found())
+
+	result, err := manager.Apply(resources)
+	t.Log(result)
+	require.NoError(t, err)
+	assert.Equal(t, ActionCreate, result[0].action)
+
+	stat, err := os.Stat(filepath.Join(provider.Prefix, resource.Path))
+	assert.NoError(t, err)
+	assert.Equal(t, fs.FileMode(0644).String(), stat.Mode().String())
+}
+
+func TestFileContentUpdateKeepExisting(t *testing.T) {
+	providerName := "test-files"
+	provider := FileProvider{
+		Prefix: t.TempDir(),
+	}
+	manager := NewManager()
+	manager.RegisterProvider(providerName, &provider)
+
+	content := "somecontent"
+	resource := File{
+		Provider:            providerName,
+		Path:                "/sample-file.txt",
+		Content:             FileContentLiteral(content),
+		KeepExistingContent: true,
+	}
+	resources := Resources{&resource}
+
+	state, err := resource.Get(manager.Context(nil))
+	require.NoError(t, err)
+	assert.False(t, state.Found())
+
+	oldContent := []byte("old content")
+	err = ioutil.WriteFile(filepath.Join(provider.Prefix, resource.Path), oldContent, 0644)
+	require.NoError(t, err)
+
+	state, err = resource.Get(manager.Context(nil))
+	require.NoError(t, err)
+	assert.True(t, state.Found())
+
+	// It shouldn't update the content.
+	result, err := manager.Apply(resources)
+	t.Log(result)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+
+	d, err := ioutil.ReadFile(filepath.Join(provider.Prefix, resource.Path))
+	require.NoError(t, err)
+	assert.Equal(t, string(oldContent), string(d))
+}
+
+func TestFileContentUpdateKeepExistingChangeMode(t *testing.T) {
+	providerName := "test-files"
+	provider := FileProvider{
+		Prefix: t.TempDir(),
+	}
+	manager := NewManager()
+	manager.RegisterProvider(providerName, &provider)
+
+	content := "somecontent"
+	resource := File{
+		Provider:            providerName,
+		Path:                "/sample-file.txt",
+		Content:             FileContentLiteral(content),
+		Mode:                FileMode(0644),
+		KeepExistingContent: true,
+	}
+	resources := Resources{&resource}
+
+	state, err := resource.Get(manager.Context(nil))
+	require.NoError(t, err)
+	assert.False(t, state.Found())
+
+	oldContent := []byte("old content")
+	err = ioutil.WriteFile(filepath.Join(provider.Prefix, resource.Path), oldContent, 0777)
+	require.NoError(t, err)
+
+	state, err = resource.Get(manager.Context(nil))
+	require.NoError(t, err)
+	assert.True(t, state.Found())
+
+	// It shouldn't update the content.
+	result, err := manager.Apply(resources)
+	t.Log(result)
+	require.NoError(t, err)
+	if assert.NotEmpty(t, result, "expecting update") {
+		assert.Equal(t, ActionUpdate, result[0].action)
+	}
+
+	d, err := ioutil.ReadFile(filepath.Join(provider.Prefix, resource.Path))
+	require.NoError(t, err)
+	assert.Equal(t, string(oldContent), string(d))
+
+	info, err := os.Stat(filepath.Join(provider.Prefix, resource.Path))
+	assert.NoError(t, err)
+	assert.Equal(t, resource.Mode.String(), info.Mode().String())
+}
+
 func TestFileDefaultProvider(t *testing.T) {
 	manager := NewManager()
 


### PR DESCRIPTION
Add new parameter `KeepExistingContent` to allow to avoid overwriting the content of existing files.