### PR TITLE
[breaking] Use standard contexts

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -44,7 +44,7 @@ func TestFilePresent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -74,7 +74,7 @@ func TestFileContent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -104,14 +104,14 @@ func TestFileContentUpdate(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), []byte("old content"), 0644)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.Context(context.Background()))
+	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -149,7 +149,7 @@ func TestFilePresentWithKeepExisting(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -180,7 +180,7 @@ func TestFileContentUpdateKeepExisting(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -188,7 +188,7 @@ func TestFileContentUpdateKeepExisting(t *testing.T) {
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), oldContent, 0644)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.Context(context.Background()))
+	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -225,7 +225,7 @@ func TestFileContentUpdateKeepExistingChangeMode(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -233,7 +233,7 @@ func TestFileContentUpdateKeepExistingChangeMode(t *testing.T) {
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), oldContent, 0777)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.Context(context.Background()))
+	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -262,7 +262,7 @@ func TestFileDefaultProvider(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -288,7 +288,7 @@ func TestFileOverrideDefaultProvider(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -316,7 +316,7 @@ func TestFileAbsent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -324,7 +324,7 @@ func TestFileAbsent(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	state, err = resource.Get(manager.Context(context.Background()))
+	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -361,7 +361,7 @@ func TestFileInSubdirectory(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -389,7 +389,7 @@ func TestFileDirectory(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -423,7 +423,7 @@ func TestFileToDirectoryUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -459,7 +459,7 @@ func TestDirectoryToFileUpdate(t *testing.T) {
 	err := os.Mkdir(filepath.Join(provider.Prefix, resource.Path), 0755)
 	require.NoError(t, err)
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 

--- a/filecontent.go
+++ b/filecontent.go
@@ -18,6 +18,7 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 	"io"
 )
@@ -25,11 +26,11 @@ import (
 // FileContent defines the content of a file. It recives an apply context
 // to obtain information from the execution, and a writer where to write
 // the content.
-type FileContent func(Context, io.Writer) error
+type FileContent func(context.Context, io.Writer) error
 
 // FileContentLiteral returns a literal file content.
 func FileContentLiteral(content string) FileContent {
-	return func(_ Context, w io.Writer) error {
+	return func(_ context.Context, w io.Writer) error {
 		_, err := fmt.Fprint(w, content)
 		return err
 	}

--- a/filesource_test.go
+++ b/filesource_test.go
@@ -48,7 +48,7 @@ func TestFileContentFromSourceFile(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -84,7 +84,7 @@ func TestFileContentFromSourceTemplate(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -120,7 +120,7 @@ func TestFileContentFromSourceURL(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 

--- a/manager.go
+++ b/manager.go
@@ -143,17 +143,20 @@ func NewManager() *Manager {
 	}
 }
 
-const ContextRuntimeKey = "resource_runtime"
+// contextKey is a custom type to avoid collisions in key values.
+type contextKey int
+
+const contextRuntimeKey contextKey = iota
 
 // ContextWithRuntime returns a resource context that wraps the given context and the manager.
 func (m *Manager) ContextWithRuntime(ctx context.Context) context.Context {
-	return context.WithValue(ctx, ContextRuntimeKey, m)
+	return context.WithValue(ctx, contextRuntimeKey, m)
 }
 
 // RuntimeFromContext obtains a runtime from a context. The context must contain a runtime,
 // otherwise this call will panic.
 func RuntimeFromContext(ctx context.Context) Runtime {
-	v := ctx.Value(ContextRuntimeKey)
+	v := ctx.Value(contextRuntimeKey)
 	runtime, ok := v.(Runtime)
 	if !ok {
 		panic("context without resources runtime")

--- a/manager_test.go
+++ b/manager_test.go
@@ -98,14 +98,14 @@ type dummyResource struct {
 	createError error
 }
 
-func (r *dummyResource) Get(Context) (ResourceState, error) {
+func (r *dummyResource) Get(context.Context) (ResourceState, error) {
 	return &dummyResourceState{
 		absent:      r.absent,
 		needsUpdate: r.needsUpdate,
 	}, nil
 }
-func (r *dummyResource) Create(Context) error { return r.createError }
-func (r *dummyResource) Update(Context) error { return nil }
+func (r *dummyResource) Create(context.Context) error { return r.createError }
+func (r *dummyResource) Update(context.Context) error { return nil }
 
 type dummyResourceState struct {
 	absent      bool


### PR DESCRIPTION
Replace the concept of context from the library, and use standard contexts instead.

The extended functionality provided before by these contexts is provided now by the new concept of "Runtime".

A new helper is added to the manager to enrich a standard context with a runtime. Also a helper function is added to get a runtime from a context.
```
ctx := manager.ContextWithRuntime(ctx)
...
runtime := resource.RuntimeFromContext(ctx)
```

This change is breaking for implementation of resource types. It should be transparent for users of resources.