### PR TITLE
[breaking] Split context into stdlib context and new scope object

### DIFF
--- a/file.go
+++ b/file.go
@@ -244,7 +244,6 @@ func (f *File) Update(ctx context.Context, scope Scope) error {
 type FileState struct {
 	info     fs.FileInfo
 	expected bool
-	context  context.Context
 	scope    Scope
 	content  func() (io.ReadCloser, error)
 }

--- a/file_test.go
+++ b/file_test.go
@@ -44,9 +44,9 @@ func TestFilePresent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -74,9 +74,9 @@ func TestFileContent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -104,16 +104,16 @@ func TestFileContentUpdate(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), []byte("old content"), 0644)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err = resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.True(t, state.Found())
+	assert.True(t, state.Found(context.Background()))
 
 	// On first apply, it should update the content to the expected one.
 	result, err := manager.Apply(resources)
@@ -149,9 +149,9 @@ func TestFilePresentWithKeepExisting(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -180,17 +180,17 @@ func TestFileContentUpdateKeepExisting(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	oldContent := []byte("old content")
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), oldContent, 0644)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err = resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.True(t, state.Found())
+	assert.True(t, state.Found(context.Background()))
 
 	// It shouldn't update the content.
 	result, err := manager.Apply(resources)
@@ -225,17 +225,17 @@ func TestFileContentUpdateKeepExistingChangeMode(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	oldContent := []byte("old content")
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), oldContent, 0777)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err = resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.True(t, state.Found())
+	assert.True(t, state.Found(context.Background()))
 
 	// It shouldn't update the content.
 	result, err := manager.Apply(resources)
@@ -262,9 +262,9 @@ func TestFileDefaultProvider(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -288,9 +288,9 @@ func TestFileOverrideDefaultProvider(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -316,17 +316,17 @@ func TestFileAbsent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.True(t, state.Found())
+	assert.True(t, state.Found(context.Background()))
 
 	f, err := os.Create(filepath.Join(provider.Prefix, resource.Path))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err = resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.True(t, state.Found())
+	assert.True(t, state.Found(context.Background()))
 
 	// On first apply, it should remove the file.
 	result, err := manager.Apply(resources)
@@ -361,9 +361,9 @@ func TestFileInSubdirectory(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -389,9 +389,9 @@ func TestFileDirectory(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -423,9 +423,9 @@ func TestFileToDirectoryUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.True(t, state.Found())
+	assert.True(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -459,9 +459,9 @@ func TestDirectoryToFileUpdate(t *testing.T) {
 	err := os.Mkdir(filepath.Join(provider.Prefix, resource.Path), 0755)
 	require.NoError(t, err)
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.True(t, state.Found())
+	assert.True(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)

--- a/file_test.go
+++ b/file_test.go
@@ -44,7 +44,7 @@ func TestFilePresent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -74,7 +74,7 @@ func TestFileContent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -104,14 +104,14 @@ func TestFileContentUpdate(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), []byte("old content"), 0644)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.Context(context.Background()))
+	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -149,7 +149,7 @@ func TestFilePresentWithKeepExisting(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -180,7 +180,7 @@ func TestFileContentUpdateKeepExisting(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -188,7 +188,7 @@ func TestFileContentUpdateKeepExisting(t *testing.T) {
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), oldContent, 0644)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.Context(context.Background()))
+	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -225,7 +225,7 @@ func TestFileContentUpdateKeepExistingChangeMode(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -233,7 +233,7 @@ func TestFileContentUpdateKeepExistingChangeMode(t *testing.T) {
 	err = os.WriteFile(filepath.Join(provider.Prefix, resource.Path), oldContent, 0777)
 	require.NoError(t, err)
 
-	state, err = resource.Get(manager.Context(context.Background()))
+	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -262,7 +262,7 @@ func TestFileDefaultProvider(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -288,7 +288,7 @@ func TestFileOverrideDefaultProvider(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -316,7 +316,7 @@ func TestFileAbsent(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -324,7 +324,7 @@ func TestFileAbsent(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	state, err = resource.Get(manager.Context(context.Background()))
+	state, err = resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -361,7 +361,7 @@ func TestFileInSubdirectory(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -389,7 +389,7 @@ func TestFileDirectory(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -423,7 +423,7 @@ func TestFileToDirectoryUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 
@@ -459,7 +459,7 @@ func TestDirectoryToFileUpdate(t *testing.T) {
 	err := os.Mkdir(filepath.Join(provider.Prefix, resource.Path), 0755)
 	require.NoError(t, err)
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.True(t, state.Found())
 

--- a/filecontent.go
+++ b/filecontent.go
@@ -26,11 +26,11 @@ import (
 // FileContent defines the content of a file. It recives an apply context
 // to obtain information from the execution, and a writer where to write
 // the content.
-type FileContent func(context.Context, io.Writer) error
+type FileContent func(context.Context, Scope, io.Writer) error
 
 // FileContentLiteral returns a literal file content.
 func FileContentLiteral(content string) FileContent {
-	return func(_ context.Context, w io.Writer) error {
+	return func(_ context.Context, _ Scope, w io.Writer) error {
 		_, err := fmt.Fprint(w, content)
 		return err
 	}

--- a/filecontent.go
+++ b/filecontent.go
@@ -18,6 +18,7 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 	"io"
 )
@@ -25,11 +26,11 @@ import (
 // FileContent defines the content of a file. It recives an apply context
 // to obtain information from the execution, and a writer where to write
 // the content.
-type FileContent func(Context, io.Writer) error
+type FileContent func(context.Context, io.Writer) error
 
 // FileContentLiteral returns a literal file content.
 func FileContentLiteral(content string) FileContent {
-	return func(_ Context, w io.Writer) error {
+	return func(_ context.Context, w io.Writer) error {
 		_, err := fmt.Fprint(w, content)
 		return err
 	}

--- a/filesource.go
+++ b/filesource.go
@@ -50,7 +50,7 @@ func (s *SourceFS) WithTemplateFuncs(fmap template.FuncMap) *SourceFS {
 
 // File returns the file content for a given path in the source file system.
 func (s *SourceFS) File(path string) FileContent {
-	return func(_ context.Context, w io.Writer) error {
+	return func(_ context.Context, _ Scope, w io.Writer) error {
 		f, err := s.FS.Open(path)
 		if err != nil {
 			return err
@@ -67,11 +67,10 @@ func (s *SourceFS) File(path string) FileContent {
 // The template can use the `fact(string) string`  function, as well as other functions
 // defined with `WithTemplateFuncs`.
 func (s *SourceFS) Template(path string) FileContent {
-	return func(ctx context.Context, w io.Writer) error {
-		runtime := RuntimeFromContext(ctx)
+	return func(_ context.Context, scope Scope, w io.Writer) error {
 		fmap := template.FuncMap{
 			"fact": func(name string) (string, error) {
-				v, found := runtime.Fact(name)
+				v, found := scope.Fact(name)
 				if !found {
 					return "", fmt.Errorf("fact %q not found", name)
 				}
@@ -99,7 +98,7 @@ type HTTPSource struct {
 
 // Get obtains the content with an http request to the given location.
 func (s *HTTPSource) Get(location string) FileContent {
-	return func(ctx context.Context, w io.Writer) error {
+	return func(ctx context.Context, _ Scope, w io.Writer) error {
 		client := s.Client
 		if client == nil {
 			client = http.DefaultClient

--- a/filesource_test.go
+++ b/filesource_test.go
@@ -48,7 +48,7 @@ func TestFileContentFromSourceFile(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -84,7 +84,7 @@ func TestFileContentFromSourceTemplate(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 
@@ -120,7 +120,7 @@ func TestFileContentFromSourceURL(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.Context(context.Background()))
+	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
 	require.NoError(t, err)
 	assert.False(t, state.Found())
 

--- a/filesource_test.go
+++ b/filesource_test.go
@@ -48,9 +48,9 @@ func TestFileContentFromSourceFile(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -84,9 +84,9 @@ func TestFileContentFromSourceTemplate(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)
@@ -120,9 +120,9 @@ func TestFileContentFromSourceURL(t *testing.T) {
 	}
 	resources := Resources{&resource}
 
-	state, err := resource.Get(manager.ContextWithRuntime(context.Background()))
+	state, err := resource.Get(context.Background(), manager)
 	require.NoError(t, err)
-	assert.False(t, state.Found())
+	assert.False(t, state.Found(context.Background()))
 
 	result, err := manager.Apply(resources)
 	t.Log(result)

--- a/manager.go
+++ b/manager.go
@@ -143,17 +143,20 @@ func NewManager() *Manager {
 	}
 }
 
-const ContextRuntimeKey = "resource_runtime"
+// contextKey is a custom type to avoid collisions in key values.
+type contextKey int
+
+const contextRuntimeKey contextKey = iota
 
 // ContextWithRuntime returns a resource context that wraps the given context and the manager.
 func (m *Manager) ContextWithRuntime(ctx context.Context) context.Context {
-	return context.WithValue(ctx, ContextRuntimeKey, m)
+	return context.WithValue(ctx, contextRuntimeKey, m)
 }
 
 // RuntimeFromContext obtains a runtime from a context. The context must contain a runtime,
 // otherwise this call will panic.
 func RuntimeFromContext(ctx context.Context) Runtime {
-	v := ctx.Value(ContextRuntimeKey)
+	v := ctx.Value(contextRuntimeKey)
 	runtime, ok := v.(Runtime)
 	if !ok {
 		panic("context without resources runtime")

--- a/manager_test.go
+++ b/manager_test.go
@@ -98,14 +98,14 @@ type dummyResource struct {
 	createError error
 }
 
-func (r *dummyResource) Get(Context) (ResourceState, error) {
+func (r *dummyResource) Get(context.Context) (ResourceState, error) {
 	return &dummyResourceState{
 		absent:      r.absent,
 		needsUpdate: r.needsUpdate,
 	}, nil
 }
-func (r *dummyResource) Create(Context) error { return r.createError }
-func (r *dummyResource) Update(Context) error { return nil }
+func (r *dummyResource) Create(context.Context) error { return r.createError }
+func (r *dummyResource) Update(context.Context) error { return nil }
 
 type dummyResourceState struct {
 	absent      bool

--- a/manager_test.go
+++ b/manager_test.go
@@ -98,21 +98,21 @@ type dummyResource struct {
 	createError error
 }
 
-func (r *dummyResource) Get(context.Context) (ResourceState, error) {
+func (r *dummyResource) Get(context.Context, Scope) (ResourceState, error) {
 	return &dummyResourceState{
 		absent:      r.absent,
 		needsUpdate: r.needsUpdate,
 	}, nil
 }
-func (r *dummyResource) Create(context.Context) error { return r.createError }
-func (r *dummyResource) Update(context.Context) error { return nil }
+func (r *dummyResource) Create(context.Context, Scope) error { return r.createError }
+func (r *dummyResource) Update(context.Context, Scope) error { return nil }
 
 type dummyResourceState struct {
 	absent      bool
 	needsUpdate bool
 }
 
-func (s *dummyResourceState) Found() bool { return !s.absent }
-func (s *dummyResourceState) NeedsUpdate(definition Resource) (bool, error) {
+func (s *dummyResourceState) Found(context.Context) bool { return !s.absent }
+func (s *dummyResourceState) NeedsUpdate(context.Context, Resource) (bool, error) {
 	return s.needsUpdate, nil
 }


### PR DESCRIPTION
Alternative to https://github.com/elastic/go-resource/pull/8, with less magic.

Replace the concept of context from the library, and use standard contexts instead.

The extended functionality provided before by these contexts is provided now by the new concept of "Scope".

`Resource` interface methods have been modified, so they receive now a normal `context.Context` with no expectations on it, plus a `Scope`.

This change is breaking for implementation of resource types and other extensions. It should be transparent for users of resources.
