### PR TITLE
ci: move from dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 .github/ @elastic/ecosystem
+/go.mod  @elastic/ecosystem

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,4 @@ updates:
       interval: "daily"
     labels:
       - automation
-    reviewers:
-      - "elastic/ecosystem"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Removed reviewers section in dependabot.yml and moved it's definition to CODEOWNERS.

Reviewers dependabot.yml configuration is being retired option because the functionality overlaps with [GitHub code owners](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/